### PR TITLE
feat: testing suite

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,15 @@
+# Testing locally
+
+All commands should be run from the directory containing this README.
+
+First, start the server
+
+```bash
+jupyter notebook --config=jupyter_notebook_config.py
+```
+
+Then, in a separate terminal
+
+```bash
+python3 notebook_tester.py
+```

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -5,7 +5,7 @@ All commands should be run from the directory containing this README.
 First, start the server
 
 ```bash
-jupyter notebook --config=jupyter_notebook_config.py
+FCC_ENVIRONMENT=TESTING jupyter notebook --config=jupyter_notebook_config.py
 ```
 
 Then, in a separate terminal

--- a/experiments/jupyter_notebook_config.py
+++ b/experiments/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+# Since the tests are intended to be run locally or in CI we disable the authentication.
+c.NotebookApp.disable_check_xsrf = True
+c.NotebookApp.token = ""

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,25 +19,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error: var should contain the 'demo' string!\n"
+      "Error: sqrt(25) should return 5, but got 5.0990195135927845\n"
      ]
     }
    ],
    "source": [
-    "var = ___\n",
+    "import math\n",
+    "def sqrt(x):\n",
+    "    return math.sqrt(x + 1) # adding 1 to make sure it fails the tests\n",
+    "    \n",
     "runner.run(tests.step01)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -1,15 +1,38 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Welcome to the notebook!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tests; tests.prepare(globals(), In)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tests; tests.prepare(globals(), In)\n",
-    "\n",
-    "var = \"some text\"\n",
-    "\n",
+    "var = \"demo\"\n",
+    "tests.step01()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var = 'demo'\n",
     "tests.step01()"
    ]
   }

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -9,24 +9,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tests; tests.prepare(globals(), In); \n",
-    "import test_runner; runner = test_runner.TestRunner({'catch_exceptions': True})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error: single quotes please!\n"
+      "env: FCC_ENVIRONMENT=TESTING\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tests; tests.prepare(globals(), In);\n",
+    "import test_runner; runner = test_runner.TestRunner()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "single quotes please!",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m/media/external/Code/fcc/math/experiments/notebook.ipynb Cell 3'\u001b[0m in \u001b[0;36m<cell line: 2>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/media/external/Code/fcc/math/experiments/notebook.ipynb#ch0000002?line=0'>1</a>\u001b[0m var \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/media/external/Code/fcc/math/experiments/notebook.ipynb#ch0000002?line=1'>2</a>\u001b[0m runner\u001b[39m.\u001b[39;49mrun(tests\u001b[39m.\u001b[39;49mstep01)\n",
+      "File \u001b[0;32m/media/external/Code/fcc/math/experiments/test_runner.py:17\u001b[0m, in \u001b[0;36mTestRunner.run\u001b[0;34m(self, fn)\u001b[0m\n\u001b[1;32m     <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=14'>15</a>\u001b[0m         \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mError:\u001b[39m\u001b[39m\"\u001b[39m, e\u001b[39m.\u001b[39margs[\u001b[39m0\u001b[39m])\n\u001b[1;32m     <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=15'>16</a>\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m---> <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=16'>17</a>\u001b[0m     fn()\n",
+      "File \u001b[0;32m/media/external/Code/fcc/math/experiments/tests.py:6\u001b[0m, in \u001b[0;36mstep01\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=3'>4</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstep01\u001b[39m():\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=4'>5</a>\u001b[0m     \u001b[39massert\u001b[39;00m user_env\u001b[39m.\u001b[39mgetVariable(\u001b[39m\"\u001b[39m\u001b[39mvar\u001b[39m\u001b[39m\"\u001b[39m) \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mvar should contain the \u001b[39m\u001b[39m'\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m'\u001b[39m\u001b[39m string!\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=5'>6</a>\u001b[0m     \u001b[39massert\u001b[39;00m re\u001b[39m.\u001b[39msearch(\u001b[39m\"\u001b[39m\u001b[39m'\u001b[39m\u001b[39m\\\u001b[39m\u001b[39mw*\u001b[39m\u001b[39m'\u001b[39m\u001b[39m\"\u001b[39m, user_env\u001b[39m.\u001b[39mgetCode()), \u001b[39m'\u001b[39m\u001b[39msingle quotes please!\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=6'>7</a>\u001b[0m     \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mStep 01: Success!\u001b[39m\u001b[39m\"\u001b[39m)\n",
+      "\u001b[0;31mAssertionError\u001b[0m: single quotes please!"
      ]
     }
    ],
@@ -37,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -13,27 +13,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tests; tests.prepare(globals(), In)"
+    "import tests; tests.prepare(globals(), In); \n",
+    "import test_runner; runner = test_runner.TestRunner({'catch_exceptions': True})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: single quotes please!\n"
+     ]
+    }
+   ],
    "source": [
     "var = \"demo\"\n",
-    "tests.step01()"
+    "runner.run(tests.step01)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Step 01: Success!\n"
+     ]
+    }
+   ],
    "source": [
     "var = 'demo'\n",
-    "tests.step01()"
+    "runner.run(tests.step01)"
    ]
   }
  ],

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tests; tests.prepare(globals(), In)\n",
+    "\n",
+    "var = \"some text\"\n",
+    "\n",
+    "tests.step01()"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.10 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/experiments/notebook.ipynb
+++ b/experiments/notebook.ipynb
@@ -9,17 +9,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: FCC_ENVIRONMENT=TESTING\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import tests; tests.prepare(globals(), In);\n",
     "import test_runner; runner = test_runner.TestRunner()"
@@ -27,44 +19,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "single quotes please!",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[1;32m/media/external/Code/fcc/math/experiments/notebook.ipynb Cell 3'\u001b[0m in \u001b[0;36m<cell line: 2>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/media/external/Code/fcc/math/experiments/notebook.ipynb#ch0000002?line=0'>1</a>\u001b[0m var \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/media/external/Code/fcc/math/experiments/notebook.ipynb#ch0000002?line=1'>2</a>\u001b[0m runner\u001b[39m.\u001b[39;49mrun(tests\u001b[39m.\u001b[39;49mstep01)\n",
-      "File \u001b[0;32m/media/external/Code/fcc/math/experiments/test_runner.py:17\u001b[0m, in \u001b[0;36mTestRunner.run\u001b[0;34m(self, fn)\u001b[0m\n\u001b[1;32m     <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=14'>15</a>\u001b[0m         \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mError:\u001b[39m\u001b[39m\"\u001b[39m, e\u001b[39m.\u001b[39margs[\u001b[39m0\u001b[39m])\n\u001b[1;32m     <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=15'>16</a>\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m---> <a href='file:///media/external/Code/fcc/math/experiments/test_runner.py?line=16'>17</a>\u001b[0m     fn()\n",
-      "File \u001b[0;32m/media/external/Code/fcc/math/experiments/tests.py:6\u001b[0m, in \u001b[0;36mstep01\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=3'>4</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstep01\u001b[39m():\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=4'>5</a>\u001b[0m     \u001b[39massert\u001b[39;00m user_env\u001b[39m.\u001b[39mgetVariable(\u001b[39m\"\u001b[39m\u001b[39mvar\u001b[39m\u001b[39m\"\u001b[39m) \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mvar should contain the \u001b[39m\u001b[39m'\u001b[39m\u001b[39mdemo\u001b[39m\u001b[39m'\u001b[39m\u001b[39m string!\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=5'>6</a>\u001b[0m     \u001b[39massert\u001b[39;00m re\u001b[39m.\u001b[39msearch(\u001b[39m\"\u001b[39m\u001b[39m'\u001b[39m\u001b[39m\\\u001b[39m\u001b[39mw*\u001b[39m\u001b[39m'\u001b[39m\u001b[39m\"\u001b[39m, user_env\u001b[39m.\u001b[39mgetCode()), \u001b[39m'\u001b[39m\u001b[39msingle quotes please!\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m      <a href='file:///media/external/Code/fcc/math/experiments/tests.py?line=6'>7</a>\u001b[0m     \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mStep 01: Success!\u001b[39m\u001b[39m\"\u001b[39m)\n",
-      "\u001b[0;31mAssertionError\u001b[0m: single quotes please!"
-     ]
-    }
-   ],
-   "source": [
-    "var = \"demo\"\n",
-    "runner.run(tests.step01)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 01: Success!\n"
+      "Error: var should contain the 'demo' string!\n"
      ]
     }
    ],
    "source": [
-    "var = 'demo'\n",
+    "var = ___\n",
     "runner.run(tests.step01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: variable a should contain the 'ay' string!\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = ___\n",
+    "b = ___\n",
+    "runner.run(tests.step02)"
    ]
   }
  ],

--- a/experiments/notebook_tester.py
+++ b/experiments/notebook_tester.py
@@ -1,0 +1,84 @@
+import websocket
+import requests
+import json
+import uuid
+from datetime import datetime
+
+notebook_filename = "notebook.ipynb"
+jupyter_host = "localhost:8888"
+kernel_url = "http://" + jupyter_host + "/api/kernels"
+
+kernel_info = json.loads(requests.post(kernel_url).text)
+session = str(uuid.uuid4())
+
+notebook_url = "http://" + jupyter_host + "/api/contents/" + notebook_filename
+notebook = json.loads(requests.get(notebook_url).text)
+
+# TODO: separate out the cells with tests from those without
+seed_code = list(
+    map(
+        lambda cell: cell["source"],
+        filter(lambda cell: cell["cell_type"] == "code", notebook["content"]["cells"]),
+    )
+)
+
+
+def create_execute_request(code):
+    return create_message(
+        "execute_request", {"code": code, "silent": False, "allow_stdin": True}
+    )
+
+
+def create_input_reply(value):
+    return create_message("input_reply", {"value": value}, "stdin")
+
+
+def create_message(msg_type, content, channel="shell"):
+    return {
+        "header": create_header(msg_type),
+        "parent_header": {},
+        "metadata": {},
+        "content": content,
+        "channel": channel,
+    }
+
+
+def create_header(msg_type):
+    return {
+        "msg_id": str(uuid.uuid4()),
+        "username": "test",
+        "session": session,
+        "date": datetime.now().isoformat(),
+        "msg_type": msg_type,
+        "version": "5.0",
+    }
+
+
+ws = websocket.WebSocket()
+ws.connect("ws://" + jupyter_host + "/api/kernels/" + kernel_info["id"] + "/channels")
+
+# TODO: each entry in 'code' should either be a test or not. If it is a test it
+# needs a solution and a seed.  The seed should generate errors then the
+# solution should not. If it's not a test, it does not need a solution and
+# should execute without errors.
+for seed in seed_code:
+    req = create_execute_request(seed)
+    print("Sending:", req)
+    ws.send(json.dumps(req))
+    processing = True
+    while processing:
+        res = json.loads(ws.recv())
+        if res["msg_type"] == "execute_reply":
+            # TODO: check that the seed fails
+            if res["content"]["status"] == "error":
+                print("Error:", res)
+            else:
+                print("Success:", res)
+            processing = False
+        if res["msg_type"] == "input_request":
+            # TODO: use the right input for this request
+            req = create_input_reply("dummy data")
+            print("Sending reply:", req)
+            ws.send(json.dumps(req))
+
+ws.close()

--- a/experiments/notebook_tester.py
+++ b/experiments/notebook_tester.py
@@ -61,7 +61,7 @@ ws = websocket.WebSocket()
 ws.connect("ws://" + jupyter_host + "/api/kernels/" + kernel_info["id"] + "/channels")
 
 
-def wait_for_execution(seed):
+def wait_for_execution(seed, soln=None):
     processing = True
     while processing:
         res = json.loads(ws.recv())
@@ -101,7 +101,7 @@ for (seed, soln) in zip(seed_code[1:], solutions):
     req = create_execute_request(seed, "seed")
     print("Sending:", req)
     ws.send(json.dumps(req))
-    wait_for_execution(seed)
+    wait_for_execution(seed, soln)
 
 
 ws.close()

--- a/experiments/solutions.py
+++ b/experiments/solutions.py
@@ -1,0 +1,9 @@
+solutions = [
+    """var = 'demo'
+runner.run(tests.step01)
+""",
+    """a = 'ay'
+b = 'bee'
+runner.run(tests.step02)
+""",
+]

--- a/experiments/solutions.py
+++ b/experiments/solutions.py
@@ -1,3 +1,5 @@
+# TODO: consider how to handle the non-test cells (e.g. the first one). Do we
+# want to duplicate them here?
 solutions = [
     """var = 'demo'
 runner.run(tests.step01)

--- a/experiments/test_runner.py
+++ b/experiments/test_runner.py
@@ -1,6 +1,11 @@
+import os
+
+
 class TestRunner:
-    def __init__(self, options):
-        self.catch_exceptions = options["catch_exceptions"]
+    def __init__(self):
+        self.catch_exceptions = (
+            False if os.environ.get("FCC_ENVIRONMENT") == "TESTING" else True
+        )
 
     def run(self, fn):
         if self.catch_exceptions:

--- a/experiments/test_runner.py
+++ b/experiments/test_runner.py
@@ -1,0 +1,12 @@
+class TestRunner:
+    def __init__(self, options):
+        self.catch_exceptions = options["catch_exceptions"]
+
+    def run(self, fn):
+        if self.catch_exceptions:
+            try:
+                fn()
+            except AssertionError as e:
+                print("Error:", e.args[0])
+        else:
+            fn()

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -3,20 +3,17 @@ import re
 
 
 def step01():
-    assert (
-        user_env.var("var") == "demo"
-    ), "var should contain the 'demo' string!"
-    assert re.search("'\w*'", user_env.code()), "single quotes please!"
+    assert re.search(
+        "def sqrt", user_env.code()
+    ), "Please define a function named 'sqrt'."
+    actual = user_env.var("sqrt")(25)
+    assert actual == 5, "sqrt(25) should return 5, but got " + str(actual)
     print("Step 01: Success!")
 
 
 def step02():
-    assert (
-        user_env.var("a") == "ay"
-    ), "variable a should contain the 'ay' string!"
-    assert (
-        user_env.var("b") == "bee"
-    ), "variable b should contain the 'bee' string!"
+    assert user_env.var("a") == "ay", "variable a should contain the 'ay' string!"
+    assert user_env.var("b") == "bee", "variable b should contain the 'bee' string!"
     print("Step 02: Success!")
 
 

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -1,10 +1,23 @@
 from user_env import singleton as user_env
 import re
 
+
 def step01():
-    assert user_env.getVariable("var") == "demo", "var should contain the 'demo' string!"
-    assert re.search("'\w*'", user_env.getCode()), 'single quotes please!'
+    assert (
+        user_env.getVariable("var") == "demo"
+    ), "var should contain the 'demo' string!"
+    assert re.search("'\w*'", user_env.getCode()), "single quotes please!"
     print("Step 01: Success!")
+
+
+def step02():
+    assert (
+        user_env.getVariable("a") == "ay"
+    ), "variable a should contain the 'ay' string!"
+    assert (
+        user_env.getVariable("b") == "bee"
+    ), "variable b should contain the 'bee' string!"
+    print("Step 02: Success!")
 
 
 def prepare(user_globals, user_input):

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -1,11 +1,11 @@
 from user_env import singleton as user_env
-
+import re
 
 def step01():
     print('User\'s "var" variable is set to "demo"?')
-    print(user_env.getVariable("var") == "demo")
+    assert user_env.getVariable("var") == "demo", "var should contain the 'demo' string!"
     print("User's code")
-    print(user_env.getCode())
+    assert re.search("'\w*'", user_env.getCode()), 'single quotes please!'
 
 
 def prepare(user_globals, user_input):

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -1,0 +1,13 @@
+from user_env import singleton as user_env
+
+
+def step01():
+    print('User\'s "var" variable is set to "demo"?')
+    print(user_env.getVariable("var") == "demo")
+    print("User's code")
+    print(user_env.getCode())
+
+
+def prepare(user_globals, user_input):
+    user_env.setGlobals(user_globals)
+    user_env.setInput(user_input)

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -4,22 +4,22 @@ import re
 
 def step01():
     assert (
-        user_env.getVariable("var") == "demo"
+        user_env.var("var") == "demo"
     ), "var should contain the 'demo' string!"
-    assert re.search("'\w*'", user_env.getCode()), "single quotes please!"
+    assert re.search("'\w*'", user_env.code()), "single quotes please!"
     print("Step 01: Success!")
 
 
 def step02():
     assert (
-        user_env.getVariable("a") == "ay"
+        user_env.var("a") == "ay"
     ), "variable a should contain the 'ay' string!"
     assert (
-        user_env.getVariable("b") == "bee"
+        user_env.var("b") == "bee"
     ), "variable b should contain the 'bee' string!"
     print("Step 02: Success!")
 
 
 def prepare(user_globals, user_input):
-    user_env.setGlobals(user_globals)
-    user_env.setInput(user_input)
+    user_env.set_globals(user_globals)
+    user_env.set_input(user_input)

--- a/experiments/tests.py
+++ b/experiments/tests.py
@@ -2,10 +2,9 @@ from user_env import singleton as user_env
 import re
 
 def step01():
-    print('User\'s "var" variable is set to "demo"?')
     assert user_env.getVariable("var") == "demo", "var should contain the 'demo' string!"
-    print("User's code")
     assert re.search("'\w*'", user_env.getCode()), 'single quotes please!'
+    print("Step 01: Success!")
 
 
 def prepare(user_globals, user_input):

--- a/experiments/user_env.py
+++ b/experiments/user_env.py
@@ -1,14 +1,14 @@
 class UserEnv:
-    def setGlobals(self, user_globals):
+    def set_globals(self, user_globals):
         self.globals = user_globals
 
-    def setInput(self, input):
+    def set_input(self, input):
         self.input = input
 
-    def getVariable(self, key):
+    def var(self, key):
         return self.globals[key]
 
-    def getCode(self):
+    def code(self):
         return self.input[-1]
 
 

--- a/experiments/user_env.py
+++ b/experiments/user_env.py
@@ -1,0 +1,15 @@
+class UserEnv:
+    def setGlobals(self, user_globals):
+        self.globals = user_globals
+
+    def setInput(self, input):
+        self.input = input
+
+    def getVariable(self, key):
+        return self.globals[key]
+
+    def getCode(self):
+        return self.input[-1]
+
+
+singleton = UserEnv()


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## What does this PR add?

* User variable capture
* Test runner
* Test validator

### User variables (user_env)

The user variables, once captured, can be inspected in tests

```python
assert user_env.var('hi') == 'there', 'message'
```

and called

```python
assert user_env.var('user_function')() == 'expected output', 'message'
```

and the user's input is also there in `user_env.code()` if you need to inspect it.

### Test runner (test_runner)

This just gives a simple way to print helpful messages in production/development and raise errors in test validation

### Test validator (notebook_tester)

The validator confirms two things: that the seed code fails and that the solutions do not. It achieves this by sequentially executing the seed and solution code in the target environment (an IPython kernel). This mimics a user running each cell, modifying it and then running it again.

## Contributor experience

It shouldn't really change.  It's still fine to work directly in a notebook (though it's probably easiest to work locally in, say, VSCode, than in a colab notebook).  The only real change is that we'll need solutions for each test cell.  Those can be created in the notebook, but need copying into solutions.py

## Still to come

- Validation of all the solutions (to mimic users that don't run test cells until they've worked out the answer)
- Input handling (solutions.py will probably need modifying to include an input array with each solution)
- Less terrible console output
- Expand the testing so that it can cover all notebooks, not just the one we import from /experiments